### PR TITLE
feat: add gm linker for solc 0.5

### DIFF
--- a/packages/api/compile/linkLib.js
+++ b/packages/api/compile/linkLib.js
@@ -1,0 +1,58 @@
+const ethers = require("ethers");
+const SM3 = require("../common/web3lib/sm_crypto/sm_sm3");
+const ENCRYPT_TYPE = require("../common/configuration/constant").ENCRYPT_TYPE;
+
+/**
+ * Link placeholder bytecode of contracts with external deployed library link
+ * @param {Enum} encryptType
+ * @param {String} bin
+ * @param {Object} linkReferences
+ * @param {String} libraryName
+ * @param {String} libraryAddress
+ *
+ */
+const linkLibrary = (
+  encryptType,
+  bin,
+  linkReferences,
+  libraryName,
+  libraryAddress
+) => {
+  const address = libraryAddress.replace("0x", "");
+
+  let qualifyingLibraryName;
+
+  // We parse the bytecode's linkedReferences in search of the correct path of the library (in order to construct a correctly formatted qualifyingLibraryName)
+  for (const entry of Object.entries(linkReferences)) {
+    if (libraryName in entry[1]) {
+      // From Solidity docs: Note that the fully qualified library name is the path of its source file and the library name separated by :.
+      // qualifyingLibraryName = `${path.basename(entry[0])}:${libraryName}`
+      qualifyingLibraryName = `${entry[0]}:${libraryName}`;
+      break;
+    }
+  }
+  if (typeof(qualifyingLibraryName) === "undefined") {
+    throw new Error(
+      `linkReference for library '${libraryName}' not found in contract's bytecode.`
+    );
+  }
+
+  const encodedLibraryName =
+    encryptType === ENCRYPT_TYPE.ECDSA
+      ? ethers.utils
+          .solidityKeccak256(["string"], [qualifyingLibraryName])
+          .slice(2, 36)
+      : new SM3().sum(qualifyingLibraryName, "hex").slice(0, 34);
+
+  // eslint-disable-next-line no-restricted-syntax
+  const pattern = new RegExp(`_+\\$${encodedLibraryName}\\$_+`, "g");
+  if (!pattern.exec(bin)) {
+    throw new Error(
+      `Can't find the encoding ${encodedLibraryName} of ${libraryName}'s qualifying library name ${qualifyingLibraryName} in the contract's bytecode. It's possible that the library's path (i.e. the preimage) is incorrect.`
+    );
+  }
+
+  return bin.replace(pattern, address);
+};
+
+module.exports.linkLibrary = linkLibrary;

--- a/test/contracts/v5/BN256G2.sol
+++ b/test/contracts/v5/BN256G2.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.1;
+
+library BN256G2 {
+    function healthCheck() pure public returns (uint256) {
+        return 123;
+    }
+}

--- a/test/contracts/v5/Verifier.sol
+++ b/test/contracts/v5/Verifier.sol
@@ -1,0 +1,10 @@
+pragma solidity ^0.5.0;
+
+import './BN256G2.sol';
+
+contract Verifier {
+    function healthCheck() public returns (uint256) {
+        return BN256G2.healthCheck();
+    }
+}
+

--- a/test/test_CallLibrary.js
+++ b/test/test_CallLibrary.js
@@ -61,17 +61,15 @@ describe('test for call library', function () {
     });
 
     it('v5 with linking', async () => {
-        // not supported in SM_CRYPTO mode yet
-        if (config.encryptType === ENCRYPT_TYPE.ECDSA) {
-            const contractPath = path.join(__dirname, './contracts/v5/CallLibrary.sol');
-            let contractClass = compileService.compile(contractPath, {
-                "CallLibrary": {
-                    DelegateCallLibary: '0x1234567890123456789012345678901234567890'
-                }
-            });
-            let callLibrary = contractClass.newInstance();
-            let address = await callLibrary.$deploy(web3jService);
-            should.exist(address);
-        }
+        const contractPath = path.join(__dirname, './contracts/v5/Verifier.sol');
+        let contractClass = compileService.compile(contractPath, {
+            "BN256G2.sol": {
+                BN256G2: '0x1234567890123456789012345678901234567890'
+            }
+        });
+        let callLibrary = contractClass.newInstance();
+        
+        let address = await callLibrary.$deploy(web3jService);
+        should.exist(address);
     });
 });


### PR DESCRIPTION
### Linked issue
https://github.com/FISCO-BCOS/nodejs-sdk/issues/110

### Description
Add Guomi linker to compile contracts with library dependency. Current GM linker only support solc compiler version 0.5

### QA Instructions
1. update /test/conf/config.json
```
    "encryptType": "SM_CRYPTO",
    "accounts": {
        "alice": {
            "type": "pem",
            "value": "./accounts/sm_crypto.pem"
        }
    },
...
```
2. Update node.key, node.crt, ca.crt to be GM version
3. Start fisco bcos GM version locally
4. npm test


### Open issues:
- This code works for the `Verifier.sol` with library `BN256G2`. However when testing `CallLibrary.sol`, the sm3 hash of signature is one character off. 
> The bin is:
```
608060405234801561001057600080fd5b50610165806100206000396000f3fe60806040526004361061003b576000357c01000000000000000000000000000000000000000000000000000000009004806302425b7f14610040575b600080fd5b34801561004c57600080fd5b50610055610097565b604051808273ffffffffffffffffffffffffffffffffffffffff1673ffffffffffffffffffffffffffffffffffffffff16815260200191505060405180910390f35b600073__$9a3d94ae4ada3757394f71820d036cb8d1$__635e5c50306040518163ffffffff167c010000000000000000000000000000000000000000000000000000000002815260040160206040518083038186803b1580156100f957600080fd5b505af415801561010d573d6000803e3d6000fd5b505050506040513d602081101561012357600080fd5b810190808051906020019092919050505090509056fea165627a7a72305820f07d27d9ec1b5a9e4fecdd1a2a6d7524e7ee0f0fdc2c483256d9704d071950fe0029
```
> However sm3 result is `9a3d94ae4ada3757394f7182d036cb8d11`
> Notice the missing 0 in between. `9a3d94ae4ada3757394f7182[0]d036cb8d11`

Need to further investigate the root cause. 